### PR TITLE
Upgrade `bunyan` to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "version": "1.5.6",
   "dependencies": {
-    "bunyan": "1.5.1",
+    "bunyan": "2.0.2",
     "chai": "",
     "coffee-script": "1.12.4",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Solves an issue with the `addSerializers` api
being broken in Node 6.