### PR TITLE
replace bunyan error serializer

### DIFF
--- a/logging-manager.js
+++ b/logging-manager.js
@@ -1,5 +1,20 @@
 const bunyan = require('bunyan')
 const request = require('request')
+const OError = require('@overleaf/o-error')
+
+// bunyan error serializer
+const errSerializer = function (err) {
+  if (!err || !err.stack)
+    return err;
+  return {
+    message: err.message,
+    name: err.name,
+    stack: OError.getFullStack(err),
+    info: OError.getFullInfo(err),
+    code: err.code,
+    signal: err.signal
+  };
+};
 
 const Logger = module.exports = {
   initialize(name) {
@@ -28,7 +43,11 @@ const Logger = module.exports = {
     }
     this.logger = bunyan.createLogger({
       name,
-      serializers: bunyan.stdSerializers,
+      serializers: {
+        err: errSerializer,
+        req: bunyan.stdSerializers.req,
+        res: bunyan.stdSerializers.res
+      },
       streams: loggerStreams
     })
     if (this.isProduction) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -f unix ."
   },
   "dependencies": {
+    "@overleaf/o-error": "^2.0.0",
     "bunyan": "1.8.12",
     "raven": "1.1.3",
     "request": "2.88.0"

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -28,7 +28,7 @@ describe('LoggingManager', function() {
       once: sinon.stub().yields()
     }
     this.LoggingManager = SandboxedModule.require(modulePath, {
-      globals: { console },
+      globals: { console, process },
       requires: {
         bunyan: (this.Bunyan = {
           createLogger: sinon.stub().returns(this.mockBunyanLogger),


### PR DESCRIPTION
Fixes https://github.com/overleaf/issues/issues/2039

Replaces bunyan standard `err` logger by a custom one. Tested locally, produces an error like this:

```
{  
   "name":"spelling",
   "hostname":"5e1a9170acee",
   "pid":19,
   "level":50,
   "err":{  
      "message":"custom",
      "name":"OError",
      "stack":"OError: custom\n    at Server.<anonymous> (/app/app.js:51:18)\n    at Object.onceWrapper (events.js:286:20)\n    at Server.emit (events.js:198:13)\n    at emitListeningNT (net.js:1313:10)\n    at process._tickCallback (internal/process/next_tick.js:63:19)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:832:11)\n    at startup (internal/bootstrap/node.js:283:19)\n    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)",
      "info":{  
         "more":"info"
      }
   },
   "msg":"undefined",
   "time":"2019-07-09T18:08:51.387Z",
   "v":0
}

```