### PR TITLE
[misc] fix decaff cleanup for reportedToSentry

### DIFF
--- a/logging-manager.js
+++ b/logging-manager.js
@@ -134,13 +134,11 @@ const Logger = (module.exports = {
         this.raven.captureException(error, { tags, extra, level })
 
         // put a flag on the errors to avoid reporting them multiple times
-        const result = []
         for (key in attributes) {
           value = attributes[key]
           if (value instanceof Error) {
             value.reportedToSentry = true
           }
-          return result
         }
       } catch (err) {
         // ignore Raven errors

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "http://github.com/sharelatex/logger-sharelatex.git"
   },
   "license": "AGPL-3.0-only",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "scripts": {
     "test": "mocha test/**/*.js",
     "format": "prettier-eslint '**/*.js' --list-different",

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -257,6 +257,32 @@ describe('LoggingManager', function() {
       this.logger.error({ foo: 'bar' }, 'message')
       this.captureException.callCount.should.equal(10)
     })
+
+    describe('reportedToSentry', function() {
+      it('should mark the error as reported to sentry', function() {
+        const err = new Error()
+        this.logger.error({ err }, 'message')
+        expect(this.captureException.called).to.equal(true)
+        expect(err.reportedToSentry).to.equal(true)
+      })
+
+      it('should mark two errors as reported to sentry', function() {
+        const err1 = new Error()
+        const err2 = new Error()
+        this.logger.error({ err: err1, err2 }, 'message')
+        expect(this.captureException.called).to.equal(true)
+        expect(err1.reportedToSentry).to.equal(true)
+        expect(err2.reportedToSentry).to.equal(true)
+      })
+
+      it('should not mark arbitrary objects as reported to sentry', function() {
+        const err = new Error()
+        const ctx = { foo: 'bar' }
+        this.logger.error({ err, ctx }, 'message')
+        expect(this.captureException.called).to.equal(true)
+        expect(ctx.reportedToSentry).to.equal(undefined)
+      })
+    })
   })
 
   describe('checkLogLevel', function() {


### PR DESCRIPTION
_I stumbled across this while merging upstream into my fork._

Without this patch it would bailout of the loop after processing ANY attribute.

REF: 6fe4dcbf32720282821d42140ab92593866e0772