### PR TITLE
Support file and GCE metadata as log level sources

### DIFF
--- a/logging-manager.js
+++ b/logging-manager.js
@@ -22,7 +22,6 @@ const errSerializer = function (err) {
 
 const Logger = (module.exports = {
   initialize(name) {
-    console.log('IN INIT')
     this.logLevelSource = (process.env.LOG_LEVEL_SOURCE || 'file').toLowerCase()
     this.isProduction =
       (process.env.NODE_ENV || '').toLowerCase() === 'production'
@@ -40,7 +39,6 @@ const Logger = (module.exports = {
     })
     this._setupRingBuffer()
     this._setupStackdriver()
-    console.log(this.logger)
     this._setupLogLevelChecker()
     return this
   },
@@ -256,8 +254,6 @@ const Logger = (module.exports = {
   },
 
   _setupLogLevelChecker() {
-    console.log('In _setupLogLevelChecker')
-    console.log(this.logger)
     if (this.isProduction) {
       // clear interval if already set
       if (this.checkInterval) {

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -22,7 +22,7 @@ const errSerializer = function (err) {
 
 const Logger = (module.exports = {
   initialize(name) {
-    console.log("IN INIT")
+    console.log('IN INIT')
     this.logLevelSource = (process.env.LOG_LEVEL_SOURCE || 'file').toLowerCase()
     this.isProduction =
       (process.env.NODE_ENV || '').toLowerCase() === 'production'
@@ -60,18 +60,18 @@ const Logger = (module.exports = {
   },
 
   async getTracingEndTimeFile() {
-      return fs.promises.readFile('/logging/tracingEndTime')
+    return fs.promises.readFile('/logging/tracingEndTime')
   },
 
-async getTracingEndTimeMetadata() {
+  async getTracingEndTimeMetadata() {
     const options = {
       headers: {
         'Metadata-Flavor': 'Google'
       }
     }
     const uri = `http://metadata.google.internal/computeMetadata/v1/project/attributes/${this.loggerName}-setLogLevelEndTime`
-    const res = await fetch(uri,options)
-    if (!res.ok) throw new Error("Metadata not okay")
+    const res = await fetch(uri, options)
+    if (!res.ok) throw new Error('Metadata not okay')
     return res.text()
   },
 
@@ -256,7 +256,7 @@ async getTracingEndTimeMetadata() {
   },
 
   _setupLogLevelChecker() {
-    console.log("In _setupLogLevelChecker")
+    console.log('In _setupLogLevelChecker')
     console.log(this.logger)
     if (this.isProduction) {
       // clear interval if already set
@@ -266,7 +266,7 @@ async getTracingEndTimeMetadata() {
       if (this.logLevelSource === 'file') {
         this.getTracingEndTime = this.getTracingEndTimeFile
       } else if (this.logLevelSource === 'gce_metadata') {
-         this.getTracingEndTime = this.getTracingEndTimeMetadata
+        this.getTracingEndTime = this.getTracingEndTimeMetadata
       } else if (this.logLevelSource === 'none') {
         return
       } else {

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -22,6 +22,7 @@ const errSerializer = function (err) {
 
 const Logger = (module.exports = {
   initialize(name) {
+    console.log("IN INIT")
     this.logLevelSource = (process.env.LOG_LEVEL_SOURCE || 'file').toLowerCase()
     this.isProduction =
       (process.env.NODE_ENV || '').toLowerCase() === 'production'
@@ -39,6 +40,7 @@ const Logger = (module.exports = {
     })
     this._setupRingBuffer()
     this._setupStackdriver()
+    console.log(this.logger)
     this._setupLogLevelChecker()
     return this
   },
@@ -52,6 +54,7 @@ const Logger = (module.exports = {
         this.logger.level(this.defaultLevel)
       }
     } catch (err) {
+      console.log(err)
       this.logger.level(this.defaultLevel)
     }
   },
@@ -253,6 +256,8 @@ async getTracingEndTimeMetadata() {
   },
 
   _setupLogLevelChecker() {
+    console.log("In _setupLogLevelChecker")
+    console.log(this.logger)
     if (this.isProduction) {
       // clear interval if already set
       if (this.checkInterval) {
@@ -269,7 +274,9 @@ async getTracingEndTimeMetadata() {
         return
       }
       // check for log level override on startup
-      this.checkLogLevel()
+      this.checkLogLevel().catch((error) => {
+        console.log(error)
+      })
       // re-check log level every minute
       this.checkInterval = setInterval(this.checkLogLevel.bind(this), 1000 * 60)
     }

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -52,7 +52,6 @@ const Logger = (module.exports = {
         this.logger.level(this.defaultLevel)
       }
     } catch (err) {
-      console.log(err)
       this.logger.level(this.defaultLevel)
     }
   },

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -69,17 +69,12 @@ async checkLogLevelMetadata() {
       const res = await fetch(uri,options)
       if (!res.ok) throw new Error("Metadata not okay")
         const body = await res.text()
-        console.log("About to parse Int", body)
         if (parseInt(body) > Date.now()) {
-          console.log("About to set logger level to trace")
-          console.log(this.logger)
           this.logger.level('trace')
         } else {
-          console.log("About to set logger level to default")
           this.logger.level(this.defaultLevel)
         }
     } catch (err) {
-      console.log("ERROR: About to set logger level to default")
       this.logger.level(this.defaultLevel)
       return
     }

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -1,5 +1,5 @@
 const bunyan = require('bunyan')
-const request = require('request')
+const fetch = require('node-fetch')
 const fs = require('fs')
 const yn = require('yn')
 const OError = require('@overleaf/o-error')
@@ -60,19 +60,18 @@ const Logger = (module.exports = {
     const options = {
       headers: {
         'Metadata-Flavor': 'Google'
-      },
-      uri: `http://metadata.google.internal/computeMetadata/v1/project/attributes/${this.loggerName}-setLogLevelEndTime`
-    }
-    request(options, (err, response, body) => {
-      if (err) {
-        this.logger.level(this.defaultLevel)
-        return
       }
+    }
+    const uri = `http://metadata.google.internal/computeMetadata/v1/project/attributes/${this.loggerName}-setLogLevelEndTime`
+    fetch.fetch(uri,options).then(res => res.text()).then(body => {
       if (parseInt(body) > Date.now()) {
         this.logger.level('trace')
       } else {
         this.logger.level(this.defaultLevel)
       }
+    }).catch(err => {
+      this.logger.level(this.defaultLevel)
+      return
     })
   },
 

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -64,12 +64,17 @@ const Logger = (module.exports = {
     }
     const uri = `http://metadata.google.internal/computeMetadata/v1/project/attributes/${this.loggerName}-setLogLevelEndTime`
     fetch.fetch(uri,options).then(res => res.text()).then(body => {
+      console.log("About to parse Int", body)
       if (parseInt(body) > Date.now()) {
+        console.log("About to set logger level to trace")
+        console.log(this.logger)
         this.logger.level('trace')
       } else {
+        console.log("About to set logger level to default")
         this.logger.level(this.defaultLevel)
       }
     }).catch(err => {
+      console.log("ERROR: About to set logger level to default")
       this.logger.level(this.defaultLevel)
       return
     })

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -270,9 +270,7 @@ const Logger = (module.exports = {
         return
       }
       // check for log level override on startup
-      this.checkLogLevel().catch((error) => {
-        console.log(error)
-      })
+      this.checkLogLevel()
       // re-check log level every minute
       this.checkInterval = setInterval(this.checkLogLevel.bind(this), 1000 * 60)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,7 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -510,19 +511,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -551,21 +539,6 @@
         }
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -575,14 +548,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "bignumber.js": {
       "version": "9.0.0",
@@ -663,11 +628,6 @@
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
       }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -778,14 +738,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -859,14 +811,6 @@
       "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -904,11 +848,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "4.0.2",
@@ -957,15 +896,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1636,20 +1566,17 @@
         "tmp": "^0.0.33"
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1748,21 +1675,6 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1826,14 +1738,6 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "6.0.4",
@@ -2003,20 +1907,6 @@
         "mime": "^2.2.0"
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2080,16 +1970,6 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2267,11 +2147,6 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2282,11 +2157,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -2320,11 +2190,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "json-bigint": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
@@ -2333,26 +2198,17 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -2361,17 +2217,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -2612,19 +2457,6 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-    },
-    "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-    },
-    "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "requires": {
-        "mime-db": "1.44.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2889,11 +2721,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -3068,11 +2895,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -3760,11 +3582,6 @@
         "long": "^4.0.0"
       }
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3810,12 +3627,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -3897,40 +3710,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -4018,7 +3797,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sandboxed-module": {
       "version": "2.0.4",
@@ -4184,22 +3964,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -4404,15 +4168,6 @@
         "to-no-case": "^1.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -4430,19 +4185,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -4474,6 +4216,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4502,16 +4245,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "vue-eslint-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,7 +425,6 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -511,6 +510,19 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -539,6 +551,21 @@
         }
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -548,6 +575,14 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bignumber.js": {
       "version": "9.0.0",
@@ -628,6 +663,11 @@
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -738,6 +778,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -811,6 +859,14 @@
       "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -848,6 +904,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "4.0.2",
@@ -896,6 +957,15 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1566,17 +1636,20 @@
         "tmp": "^0.0.33"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1675,6 +1748,21 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1738,6 +1826,14 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "6.0.4",
@@ -1907,6 +2003,20 @@
         "mime": "^2.2.0"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1970,6 +2080,16 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2147,6 +2267,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2157,6 +2282,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -2190,6 +2320,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "json-bigint": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
@@ -2198,17 +2333,26 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -2217,6 +2361,17 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -2457,6 +2612,19 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2721,6 +2889,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -2895,6 +3068,11 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -3582,6 +3760,11 @@
         "long": "^4.0.0"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3627,8 +3810,12 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -3710,6 +3897,40 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3797,8 +4018,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sandboxed-module": {
       "version": "2.0.4",
@@ -3964,6 +4184,22 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -4168,6 +4404,15 @@
         "to-no-case": "^1.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -4185,6 +4430,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -4216,7 +4474,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4245,6 +4502,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@overleaf/o-error": "^3.0.0",
     "bunyan": "^1.8.14",
     "raven": "^2.6.4",
+    "request": "^2.88.2",
     "yn": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "AGPL-3.0-only",
   "version": "2.1.1",
   "scripts": {
-    "test": "mocha test/**/*.js",
+    "test": "mocha --grep=$MOCHA_GREP test/**/*.js",
     "format": "prettier-eslint $PWD'**/*.js' --list-different",
     "format:fix": "prettier-eslint $PWD'**/*.js' --write",
     "lint": "eslint -f unix ."

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "@google-cloud/logging-bunyan": "^3.0.0",
     "@overleaf/o-error": "^3.0.0",
     "bunyan": "^1.8.14",
+    "node-fetch": "^2.6.0",
     "raven": "^2.6.4",
-    "request": "^2.88.2",
     "yn": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "http://github.com/sharelatex/logger-sharelatex.git"
   },
   "license": "AGPL-3.0-only",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "test": "mocha --grep=$MOCHA_GREP test/**/*.js",
     "format": "prettier-eslint $PWD'**/*.js' --list-different",

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -316,7 +316,7 @@ describe('LoggingManager', function () {
 
     describe('when read errors', function () {
       beforeEach(async function () {
-        this.Fs.promises.readFile.throws(new Error('error'))
+        this.Fs.promises.readFile.throws(new Error('test read error'))
         this.logger.getTracingEndTime = this.logger.getTracingEndTimeFile
         await this.logger.checkLogLevel()
       })
@@ -330,7 +330,7 @@ describe('LoggingManager', function () {
 
     describe('when the file is empty', function () {
       beforeEach(async function () {
-        this.Fs.promises.readFile.yields(null, '')
+        this.Fs.promises.readFile.returns('')
         this.logger.getTracingEndTime = this.logger.getTracingEndTimeFile
         await this.logger.checkLogLevel()
       })
@@ -344,7 +344,7 @@ describe('LoggingManager', function () {
 
     describe('when time value returned that is less than current time', function () {
       beforeEach(async function () {
-        this.Fs.promises.readFile.yields(null, '1')
+        this.Fs.promises.readFile.returns('1')
         this.logger.getTracingEndTime = this.logger.getTracingEndTimeFile
         await this.logger.checkLogLevel()
       })
@@ -453,7 +453,7 @@ describe('LoggingManager', function () {
         describe('when level is already set', function() {
           beforeEach(async function() {
             this.bunyanLogger.level.returns(10)
-            this.fetchResponse.text = sinon.stub().resolves(this.start + 1000)
+            this.fetchResponse.text = sinon.stub().resolves((this.start + 1000).toString())
             this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
 
             await this.logger.checkLogLevel()
@@ -469,7 +469,7 @@ describe('LoggingManager', function () {
         describe('when level is not already set', function() {
           beforeEach(async function() {
             this.bunyanLogger.level.returns(20)
-            this.fetchResponse.text = sinon.stub().resolves(this.start + 1000)
+            this.fetchResponse.text = sinon.stub().resolves((this.start + 1000).toString())
             this.Fetch.fetch = sinon.stub().resolves(this.fetchResponse)            
             this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
 

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -446,7 +446,6 @@ describe('LoggingManager', function () {
               beforeEach(async function() {
                 this.bunyanLogger.level.returns(10)
                 //this.Request.yields(null, { statusCode: 200 }, this.start + 1000)
-                console.log("In test ", this.start + 1000)
                 this.fetchResponse.text = sinon.stub().resolves(this.start + 1000)
                 //this.Fetch = sinon.stub().resolves(this.fetchResponse)
 

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -80,7 +80,9 @@ describe('LoggingManager', function () {
 
   describe('initialize', function () {
     beforeEach(function () {
-      this.checkLogLevelStub = sinon.stub(this.LoggingManager, 'checkLogLevel').resolves('')
+      this.checkLogLevelStub = sinon
+        .stub(this.LoggingManager, 'checkLogLevel')
+        .resolves('')
       this.Bunyan.createLogger.reset()
     })
 
@@ -116,10 +118,9 @@ describe('LoggingManager', function () {
         this.Bunyan.createLogger.firstCall.args[0].streams[0].level.should.equal(
           'warn'
         )
-      })       
-      
-      describe('logLevelSource file', function () {
+      })
 
+      describe('logLevelSource file', function () {
         it('should run checkLogLevel', function () {
           this.checkLogLevelStub.should.have.been.calledOnce
         })
@@ -136,7 +137,6 @@ describe('LoggingManager', function () {
             this.checkLogLevelStub.should.have.been.calledThrice
           }))
       })
-
     })
 
     describe('when LOG_LEVEL set in env', function () {
@@ -302,7 +302,6 @@ describe('LoggingManager', function () {
   })
 
   describe('checkLogLevelFile', function () {
-
     it('should request log level override from the config map', async function () {
       this.logger.getTracingEndTime = this.logger.getTracingEndTimeFile
       await this.logger.checkLogLevel()
@@ -391,89 +390,93 @@ describe('LoggingManager', function () {
       this.logger = this.LoggingManager.initialize(this.loggerName)
     })
 
-    describe('checkLogLevel', function() {
-      it('should request log level override from google meta data service', async function() {
+    describe('checkLogLevel', function () {
+      it('should request log level override from google meta data service', async function () {
         this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
         await this.logger.checkLogLevel()
         const options = {
           headers: {
             'Metadata-Flavor': 'Google'
-          } 
+          }
         }
         const uri = `http://metadata.google.internal/computeMetadata/v1/project/attributes/${this.loggerName}-setLogLevelEndTime`
-        this.Fetch.should.have.been.calledWithMatch(uri,options)
+        this.Fetch.should.have.been.calledWithMatch(uri, options)
       })
 
-      describe('when request has error', function() {
-        beforeEach(async function() {
+      describe('when request has error', function () {
+        beforeEach(async function () {
           this.Fetch = sinon.stub().throws()
           this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
           await this.logger.checkLogLevel()
         })
 
-        it('should only set default level', function() {
+        it('should only set default level', function () {
           this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
             'debug'
           )
         })
       })
 
-      describe('when statusCode is not 200', function() {
-        beforeEach(async function() {
+      describe('when statusCode is not 200', function () {
+        beforeEach(async function () {
           this.fetchResponse.status = 404
           this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
           await this.logger.checkLogLevel()
         })
 
-        it('should only set default level', function() {
+        it('should only set default level', function () {
           this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
             'debug'
           )
         })
       })
 
-      describe('when time value returned that is less than current time', function() {
-        beforeEach(async function() {
+      describe('when time value returned that is less than current time', function () {
+        beforeEach(async function () {
           this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
           this.fetchResponse.text = sinon.stub().resolves('1')
           await this.logger.checkLogLevel()
         })
 
-        it('should only set default level', function() {
+        it('should only set default level', function () {
           this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
             'debug'
           )
         })
       })
 
-      describe('when time value returned that is more than current time', function() {
-        describe('when level is already set', function() {
-          beforeEach(async function() {
+      describe('when time value returned that is more than current time', function () {
+        describe('when level is already set', function () {
+          beforeEach(async function () {
             this.bunyanLogger.level.returns(10)
-            this.fetchResponse.text = sinon.stub().resolves((this.start + 1000).toString())
+            this.fetchResponse.text = sinon
+              .stub()
+              .resolves((this.start + 1000).toString())
             this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
 
             await this.logger.checkLogLevel()
           })
 
-          it('should set trace level', function() {
+          it('should set trace level', function () {
             this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
               'trace'
             )
           })
         })
 
-        describe('when level is not already set', function() {
-          beforeEach(async function() {
+        describe('when level is not already set', function () {
+          beforeEach(async function () {
             this.bunyanLogger.level.returns(20)
-            this.fetchResponse.text = sinon.stub().resolves((this.start + 1000).toString())
-            this.Fetch.fetch = sinon.stub().resolves(this.fetchResponse)            
+            this.fetchResponse.text = sinon
+              .stub()
+              .resolves((this.start + 1000).toString())
+            this.Fetch.fetch = sinon.stub().resolves(this.fetchResponse)
             this.logger.getTracingEndTime = this.logger.getTracingEndTimeMetadata
 
             await this.logger.checkLogLevel()
           })
 
-          it('should set trace level', function() {
+          it('should set trace level', function () {
             this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
               'trace'
             )

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -99,7 +99,7 @@ describe('LoggingManager', function () {
         )
       })
 
-      it('should not run getTracingEndTime', function () {
+      it('should not run checkLogLevel', function () {
         this.checkLogLevelStub.should.not.have.been.called
       })
     })

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -111,21 +111,13 @@ describe('LoggingManager', function () {
 
       afterEach(() => delete process.env.NODE_ENV)
 
-      describe('blah', function () {
-        beforeEach(function () {
-          this.logger = this.LoggingManager.initialize(this.loggerName)
-        })
-        it('should default to log level warn', function () {
-
-          const level = this.Bunyan.createLogger.firstCall.args[0].streams[0].level
-          console.log(level)
-          level.should.equal(
-            'warn'
-          )
-        })       
-      })
-
-
+      it('should default to log level warn', function () {
+        this.logger = this.LoggingManager.initialize(this.loggerName)
+        this.Bunyan.createLogger.firstCall.args[0].streams[0].level.should.equal(
+          'warn'
+        )
+      })       
+      
       describe('logLevelSource file', function () {
         beforeEach(function() {
           this.logger = this.LoggingManager.initialize(this.loggerName)
@@ -324,7 +316,7 @@ describe('LoggingManager', function () {
 
     describe('when read errors', function () {
       beforeEach(async function () {
-        this.Fs.promises.readFile.yields(new Error('error'))
+        this.Fs.promises.readFile.throws(new Error('error'))
         this.logger.getTracingEndTime = this.logger.getTracingEndTimeFile
         await this.logger.checkLogLevel()
       })

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -81,14 +81,12 @@ describe('LoggingManager', function () {
 
   describe('initialize', function () {
     beforeEach(function () {
-      this.getTracingEndTimeFileStub = sinon.stub(this.LoggingManager, 'getTracingEndTimeFile')
-      this.getTracingEndTimeMetadataStub = sinon.stub(this.LoggingManager, 'getTracingEndTimeMetadata')
+      this.checkLogLevelStub = sinon.stub(this.LoggingManager, 'checkLogLevel').resolves('')
       this.Bunyan.createLogger.reset()
     })
 
     afterEach(function () {
-      this.getTracingEndTimeFileStub.restore()
-      this.getTracingEndTimeMetadataStub.restore()
+      this.checkLogLevelStub.restore()
     })
 
     describe('not in production', function () {
@@ -103,8 +101,7 @@ describe('LoggingManager', function () {
       })
 
       it('should not run getTracingEndTime', function () {
-        this.getTracingEndTimeFileStub.should.not.have.been.called
-        this.getTracingEndTimeMetadataStub.should.not.have.been.called
+        this.checkLogLevelStub.should.not.have.been.called
       })
     })
 
@@ -119,7 +116,7 @@ describe('LoggingManager', function () {
         beforeEach(function () {
           this.logger = this.LoggingManager.initialize(this.loggerName)
         })
-        it.only('should default to log level warn', function () {
+        it('should default to log level warn', function () {
 
           const level = this.Bunyan.createLogger.firstCall.args[0].streams[0].level
           console.log(level)
@@ -136,44 +133,19 @@ describe('LoggingManager', function () {
         })
 
         it('should run checkLogLevel', function () {
-          this.getTracingEndTimeFileStub.should.have.been.calledOnce
+          this.checkLogLevelStub.should.have.been.calledOnce
         })
 
         describe('after 1 minute', () =>
           it('should run checkLogLevel again', function () {
             this.clock.tick(61 * 1000)
-            this.getTracingEndTimeFileStub.should.have.been.calledTwice
+            this.checkLogLevelStub.should.have.been.calledTwice
           }))
 
         describe('after 2 minutes', () =>
           it('should run checkLogLevel again', function () {
             this.clock.tick(121 * 1000)
-            this.getTracingEndTimeFileStub.should.have.been.calledThrice
-          }))
-      })
-
-      describe('logLevelSource gce_metadata', function () {
-        beforeEach(function () {
-          process.env.LOG_LEVEL_SOURCE = 'gce_metadata'
-          this.logger = this.LoggingManager.initialize(this.loggerName)
-        })
-
-        afterEach(() => delete process.env.LOG_LEVEL_SOURCE)
-
-        it('should run checkLogLevel', function () {
-          this.getTracingEndTimeMetadataStub.should.have.been.calledOnce
-        })
-
-        describe('after 1 minute', () =>
-          it('should run checkLogLevel again', function () {
-            this.clock.tick(61 * 1000)
-            this.getTracingEndTimeMetadataStub.should.have.been.calledTwice
-          }))
-
-        describe('after 2 minutes', () =>
-          it('should run checkLogLevel again', function () {
-            this.clock.tick(121 * 1000)
-            this.getTracingEndTimeMetadataStub.should.have.been.calledThrice
+            this.checkLogLevelStub.should.have.been.calledThrice
           }))
       })
 

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -4,7 +4,6 @@ const chai = require('chai')
 const path = require('path')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
-const { promises } = require('dns')
 
 chai.use(sinonChai)
 chai.should()

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -107,21 +107,18 @@ describe('LoggingManager', function () {
     describe('in production', function () {
       beforeEach(function () {
         process.env.NODE_ENV = 'production'
+        this.logger = this.LoggingManager.initialize(this.loggerName)
       })
 
       afterEach(() => delete process.env.NODE_ENV)
 
       it('should default to log level warn', function () {
-        this.logger = this.LoggingManager.initialize(this.loggerName)
         this.Bunyan.createLogger.firstCall.args[0].streams[0].level.should.equal(
           'warn'
         )
       })       
       
       describe('logLevelSource file', function () {
-        beforeEach(function() {
-          this.logger = this.LoggingManager.initialize(this.loggerName)
-        })
 
         it('should run checkLogLevel', function () {
           this.checkLogLevelStub.should.have.been.calledOnce

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -30,7 +30,9 @@ describe('LoggingManager', function () {
       once: sinon.stub().yields()
     }
     this.fetchResponse = {
-      text: sinon.stub().resolves('')
+      text: sinon.stub().resolves(''),
+      status: 200,
+      ok: true
     }
     this.Bunyan = {
       createLogger: sinon.stub().returns(this.bunyanLogger),
@@ -439,11 +441,14 @@ describe('LoggingManager', function () {
             describe('when level is already set', function() {
               beforeEach(function() {
                 this.bunyanLogger.level.returns(10)
-                this.Request.yields(null, { statusCode: 200 }, this.start + 1000)
+                //this.Request.yields(null, { statusCode: 200 }, this.start + 1000)
+                console.log("In test ", this.start + 1000)
+                this.fetchResponse.text = sinon.stub().resolves(this.start + 1000)
+                this.Fetch.fetch = sinon.stub().resolves(this.fetchResponse)
                 this.logger.checkLogLevel()
               })
       
-              it('should set trace level', function() {
+              it.only('should set trace level', function() {
                 this.bunyanLogger.level.should.have.been.calledOnce.and.calledWith(
                   'trace'
                 )


### PR DESCRIPTION
Previously we replaced checking GCE metadata to obtain the logger log level with checking a file. Whilst this works in Kubernetes, it is less obvious how to reproduce this for the CLSI in GCE. This PR restores checking the GCE metadata as an alternative option.

Supports https://github.com/overleaf/google-ops/issues/1123

To be used in conjunction with: https://github.com/overleaf/google-ops/pull/1163