### PR TITLE
[misc] fix prettier-eslint glob for real -- include tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "version": "2.1.1",
   "scripts": {
     "test": "mocha test/**/*.js",
-    "format": "prettier-eslint $PWD'**/*.js' --list-different",
-    "format:fix": "prettier-eslint $PWD'**/*.js' --write",
+    "format": "prettier-eslint $PWD'/**/*.js' --list-different",
+    "format:fix": "prettier-eslint $PWD'/**/*.js' --write",
     "lint": "eslint -f unix ."
   },
   "dependencies": {


### PR DESCRIPTION
I missed to add a slash in between the PWD environment variable and the glob.

This results in a partial coverage of the codebase, namely only the file on
  top-level are formatted, but tests are not.

Followup for #21 