### PR TITLE
Migrate from raven to @sentry/node

### DIFF
--- a/logging-manager.js
+++ b/logging-manager.js
@@ -72,12 +72,9 @@ const Logger = (module.exports = {
     return res.text()
   },
 
-  initializeErrorReporting(sentryDsn, options) {
+  initializeErrorReporting(dsn, options) {
     const Sentry = require('@sentry/node')
-    Sentry.init({
-      dsn: sentryDsn,
-      ...options,
-    })
+    Sentry.init({ dsn, ...options })
     this.lastErrorTimeStamp = 0 // for rate limiting on sentry reporting
     this.lastErrorCount = 0
   },

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -73,8 +73,11 @@ const Logger = (module.exports = {
   },
 
   initializeErrorReporting(sentryDsn, options) {
-    const raven = require('raven')
-    this.raven = new raven.Client(sentryDsn, options)
+    const Sentry = require('@sentry/node')
+    Sentry.init({
+      dsn: sentryDsn,
+      ...options,
+    })
     this.lastErrorTimeStamp = 0 // for rate limiting on sentry reporting
     this.lastErrorCount = 0
   },

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -207,22 +207,10 @@ const Logger = (module.exports = {
     return this.logger.warn.apply(this.logger, arguments)
   },
 
-  fatal(attributes, message, callback) {
-    if (callback == null) {
-      callback = function () {}
-    }
+  fatal(attributes, message) {
     this.logger.fatal(attributes, message)
     if (this.Sentry) {
-      var cb = function (e) {
-        // call the callback once after 'logged' or 'error' event
-        callback()
-        return (cb = function () {})
-      }
       this.captureException(attributes, message, 'fatal')
-      this.Sentry.once('logged', cb)
-      return this.Sentry.once('error', cb)
-    } else {
-      return callback()
     }
   },
 

--- a/logging-manager.js
+++ b/logging-manager.js
@@ -73,8 +73,8 @@ const Logger = (module.exports = {
   },
 
   initializeErrorReporting(dsn, options) {
-    const Sentry = require('@sentry/node')
-    Sentry.init({ dsn, ...options })
+    this.Sentry = require('@sentry/node')
+    this.Sentry.init({ dsn, ...options })
     this.lastErrorTimeStamp = 0 // for rate limiting on sentry reporting
     this.lastErrorCount = 0
   },
@@ -142,7 +142,7 @@ const Logger = (module.exports = {
         }
 
         // send the error to sentry
-        this.raven.captureException(error, { tags, extra, level })
+        this.Sentry.captureException(error, { tags, extra, level })
 
         // put a flag on the errors to avoid reporting them multiple times
         for (key in attributes) {
@@ -152,7 +152,7 @@ const Logger = (module.exports = {
           }
         }
       } catch (err) {
-        // ignore Raven errors
+        // ignore Sentry errors
       }
     }
   },
@@ -176,7 +176,7 @@ const Logger = (module.exports = {
       })
     }
     this.logger.error(attributes, message, ...Array.from(args))
-    if (this.raven != null) {
+    if (this.Sentry) {
       const MAX_ERRORS = 5 // maximum number of errors in 1 minute
       const now = new Date()
       // have we recently reported an error?
@@ -212,15 +212,15 @@ const Logger = (module.exports = {
       callback = function () {}
     }
     this.logger.fatal(attributes, message)
-    if (this.raven != null) {
+    if (this.Sentry) {
       var cb = function (e) {
         // call the callback once after 'logged' or 'error' event
         callback()
         return (cb = function () {})
       }
       this.captureException(attributes, message, 'fatal')
-      this.raven.once('logged', cb)
-      return this.raven.once('error', cb)
+      this.Sentry.once('logged', cb)
+      return this.Sentry.once('error', cb)
     } else {
       return callback()
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logger-sharelatex",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -247,6 +247,87 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@sentry/core": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.0.tgz",
+      "integrity": "sha512-Hx/WvhM5bXcXqfIiz+505TjYYfPjQ8mrxby/EWl+L7dYUCyI/W6IZKTc/MoHlLuM+JPUW9c1bw/97TzbgTzaAA==",
+      "requires": {
+        "@sentry/hub": "6.5.0",
+        "@sentry/minimal": "6.5.0",
+        "@sentry/types": "6.5.0",
+        "@sentry/utils": "6.5.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.0.tgz",
+      "integrity": "sha512-vEChnLoozOJzEJoTUvaAsK/n7IHoQFx8P1TzQmnR+8XGZJZmGHG6bBXUH0iS2a9hhR1WkoEBeiL+t96R9uyf0A==",
+      "requires": {
+        "@sentry/types": "6.5.0",
+        "@sentry/utils": "6.5.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.0.tgz",
+      "integrity": "sha512-MT83ONaBhTCFUlDIQFpsG/lq3ZjGK7jwQ10qxGadSg1KW6EvtQRg+OBwULeQ7C+nNEAhseNrC/qomZMT8brncg==",
+      "requires": {
+        "@sentry/hub": "6.5.0",
+        "@sentry/types": "6.5.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.5.0.tgz",
+      "integrity": "sha512-KSypDtc8XPoyMdL1BCdkNokNmEaf+AZhD4HTElmIKHpIyiYvM1bSqiOpVohnwR3E+5qNeVVBPoVjDpHWRaNzQg==",
+      "requires": {
+        "@sentry/core": "6.5.0",
+        "@sentry/hub": "6.5.0",
+        "@sentry/tracing": "6.5.0",
+        "@sentry/types": "6.5.0",
+        "@sentry/utils": "6.5.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.0.tgz",
+      "integrity": "sha512-6jpmYM3Lt4w6dOeK8keGAis722ooLtX5UcPbekkTufXiqKRR5VWg8DLUp7z7oD6h4GLrLbeNtCiH6h20ZW2ggw==",
+      "requires": {
+        "@sentry/hub": "6.5.0",
+        "@sentry/minimal": "6.5.0",
+        "@sentry/types": "6.5.0",
+        "@sentry/utils": "6.5.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-yQpTCIYxBsYT0GenqHNNKeXV8CSkkYlAxB1IGV2eac4IKC5ph5GW6TfDGwvlzQSQ297RsRmOSA8o3I5gGPd2yA=="
+    },
+    "@sentry/utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-CcHuaQN6vRuAsIC+3sA23NmWLRmUN0x/HNQxk0DHJylvYQdEA0AUNoLXogykaXh6NrCx4DNq9yCQTNTSC3mFxg==",
+      "requires": {
+        "@sentry/types": "6.5.0",
+        "tslib": "^1.9.3"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.0",
@@ -660,11 +741,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -764,11 +840,6 @@
         "emitter-listener": "^1.1.1"
       }
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -800,11 +871,6 @@
           "dev": true
         }
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "d64": {
       "version": "1.0.0",
@@ -2058,11 +2124,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
@@ -2406,6 +2467,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
     "make-plural": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
@@ -2419,16 +2485,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
-    },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
-      }
     },
     "messageformat": {
       "version": "2.3.0",
@@ -3642,25 +3698,6 @@
       "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
       "dev": true
     },
-    "raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -3965,11 +4002,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
@@ -4124,11 +4156,6 @@
         "readable-stream": "2 || 3"
       }
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -4183,8 +4210,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "@google-cloud/logging-bunyan": "^3.0.0",
     "@overleaf/o-error": "^3.0.0",
+    "@sentry/node": "^6.3.5",
     "bunyan": "^1.8.14",
     "node-fetch": "^2.6.0",
-    "raven": "^2.6.4",
     "yn": "^4.0.0"
   },
   "devDependencies": {

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -25,7 +25,8 @@ describe('LoggingManager', function () {
       level: sinon.stub(),
       warn: sinon.stub()
     }
-    this.ravenClient = {
+    this.Sentry = {
+      init: sinon.stub(),
       captureException: this.captureException,
       once: sinon.stub().yields()
     }
@@ -41,9 +42,6 @@ describe('LoggingManager', function () {
         req: sinon.stub(),
         res: sinon.stub()
       }
-    }
-    this.Raven = {
-      Client: sinon.stub().returns(this.ravenClient)
     }
     this.Fetch = sinon.stub().resolves(this.fetchResponse)
     this.Fs = {
@@ -63,7 +61,7 @@ describe('LoggingManager', function () {
       globals: { console, process },
       requires: {
         bunyan: this.Bunyan,
-        raven: this.Raven,
+        '@sentry/node': this.Sentry,
         'node-fetch': this.Fetch,
         fs: this.Fs,
         '@google-cloud/logging-bunyan': this.GCPLogging

--- a/test/unit/loggingManagerTests.js
+++ b/test/unit/loggingManagerTests.js
@@ -28,7 +28,6 @@ describe('LoggingManager', function () {
     this.Sentry = {
       init: sinon.stub(),
       captureException: this.captureException,
-      once: sinon.stub().yields()
     }
     this.fetchResponse = {
       text: sinon.stub().resolves(''),


### PR DESCRIPTION
This upgrades from `raven` to `@sentry/node`, which is the new version of [Sentry's Node SDK](https://docs.sentry.io/platforms/node/).